### PR TITLE
Namespace Kubernetes Annotation Key

### DIFF
--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -24,6 +24,8 @@ DOCKER_VERSION = "1.16"
 ORCHESTRATOR_ID = "docker"
 HOSTNAME = socket.gethostname()
 
+POLICY_ANNOTATION_KEY = "projectcalico.org/policy"
+
 ETCD_AUTHORITY_ENV = "ETCD_AUTHORITY"
 if ETCD_AUTHORITY_ENV not in os.environ:
     os.environ[ETCD_AUTHORITY_ENV] = 'kubernetes-master:6666'
@@ -414,10 +416,10 @@ class NetworkPlugin(object):
         annotations = self._get_metadata(pod, "annotations")
 
         # Find policy block of annotations
-        if annotations and "policy" in annotations.keys():
+        if annotations and POLICY_ANNOTATION_KEY in annotations:
             # Remove Default Rule (Allow Namespace)
             inbound_rules = []
-            rules = annotations["policy"]
+            rules = annotations[POLICY_ANNOTATION_KEY]
 
             # Rules separated by semicolons
             for rule in rules.split(";"):


### PR DESCRIPTION
During the 8/14 Kubernetes Hangout, it was recommended that Kubernetes annotation keys be namespaced per organization. 
annotation key `policy` is now `projectcalico.org/policy`

TODO: Update calico-docker [doc](https://github.com/projectcalico/calico-docker/blob/master/docs/kubernetes/KubernetesPolicy.md) to specify new key. These updates should be done in unison. 