### PR TITLE
Add coveralls support

### DIFF
--- a/build_calico_kubernetes/requirements.txt
+++ b/build_calico_kubernetes/requirements.txt
@@ -8,3 +8,5 @@ nose-parameterized
 mock==1.0.1
 docker-py==1.2.1
 requests==2.7.0
+coveralls
+


### PR DESCRIPTION
Add the coveralls package to the requirements.txt. After
applying our repo key to the CircleCI config, this should
enable Coveralls reports on CircleCI.