### PR TITLE
Second attempt at getting coveralls integrated.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,12 @@ ut-circle: binary
 	# Can't use --rm on circle
 	# Circle also requires extra options for reporting.
 	docker run \
-	-v `pwd`/calico_kubernetes:/code/calico_kubernetes \
+	-v `pwd`:/code \
 	-v $(CIRCLE_TEST_REPORTS):/circle_output \
 	-e COVERALLS_REPO_TOKEN=$(COVERALLS_REPO_TOKEN) \
 	calico/kubernetes-build bash -c \
 	'>/dev/null 2>&1 & \
-	nosetests calico_kubernetes/tests -c nose.cfg \
+	cd calico_kubernetes; nosetests tests -c nose.cfg \
 	--with-xunit --xunit-file=/circle_output/output.xml; RC=$$?;\
 	[[ ! -z "$$COVERALLS_REPO_TOKEN" ]] && coveralls || true; exit $$RC'
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Circle CI](https://circleci.com/gh/projectcalico/calico-kubernetes/tree/master.svg?style=svg)](https://circleci.com/gh/projectcalico/calico-kubernetes/tree/master) [![Slack Status](https://calicousers-slackin.herokuapp.com/badge.svg)](https://calicousers-slackin.herokuapp.com)
+[![Circle CI](https://circleci.com/gh/projectcalico/calico-kubernetes/tree/master.svg?style=svg)](https://circleci.com/gh/projectcalico/calico-kubernetes/tree/master)
+[![Coverage Status](https://coveralls.io/repos/projectcalico/calico-kubernetes/badge.svg?branch=master&service=github)](https://coveralls.io/github/projectcalico/calico-kubernetes?branch=master)
+[![Slack Status](https://calicousers-slackin.herokuapp.com/badge.svg)](https://calicousers-slackin.herokuapp.com)
 # Calico Networking for Kubernetes
 Calico can be integrated into Kubernetes using the native Kubernetes network plugin API.  Calico is particularly suitable for large Kubernetes deployments on bare metal or private clouds, where the performance and complexity costs of overlay networks can become significant. It can also be used in public clouds.
 


### PR DESCRIPTION
Previous commit didn't quite work when funneled through the
build pipeline. Fix some Makefile issues, which were preventing
coveralls from being run.

Also attach the coveralls button to the Github page.