### PR TITLE
Add logging of namespace state to plugin

### DIFF
--- a/calico_kubernetes/tests/kube_plugin_test.py
+++ b/calico_kubernetes/tests/kube_plugin_test.py
@@ -22,6 +22,10 @@ from calico_kubernetes import calico_kubernetes
 from pycalico.datastore import IF_PREFIX
 from pycalico.datastore_datatypes import Profile, Endpoint
 
+# noinspection PyUnresolvedReferences
+patch_object = patch.object
+
+
 TEST_HOST = calico_kubernetes.HOSTNAME
 TEST_ORCH_ID = calico_kubernetes.ORCHESTRATOR_ID
 
@@ -37,9 +41,9 @@ class NetworkPluginTest(unittest.TestCase):
             self.plugin = calico_kubernetes.NetworkPlugin()
 
     def test_create(self):
-        with patch.object(self.plugin, '_configure_interface',
+        with patch_object(self.plugin, '_configure_interface',
                     autospec=True) as m_configure_interface, \
-                patch.object(self.plugin, '_configure_profile',
+                patch_object(self.plugin, '_configure_profile',
                     autospec=True) as m_configure_profile:
             # Set up mock objects
             m_configure_interface.return_value = 'endpt_id'
@@ -62,7 +66,7 @@ class NetworkPluginTest(unittest.TestCase):
             m_configure_profile.assert_called_once_with('endpt_id')
 
     def test_create_error(self):
-        with patch.object(self.plugin, '_configure_interface',
+        with patch_object(self.plugin, '_configure_interface',
                     autospec=True) as m_configure_interface, \
                 patch('sys.exit', autospec=True) as m_sys_exit:
             # Set up mock objects
@@ -80,9 +84,9 @@ class NetworkPluginTest(unittest.TestCase):
             m_sys_exit.assert_called_once_with(1)
 
     def test_delete(self):
-        with patch.object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client, \
-                patch.object(self.plugin, '_docker_client', autospec=True) as m_docker_client, \
-                patch.object(self.plugin, '_container_remove', autospec=True) as m_container_remove:
+        with patch_object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client, \
+                patch_object(self.plugin, '_docker_client', autospec=True) as m_docker_client, \
+                patch_object(self.plugin, '_container_remove', autospec=True) as m_container_remove:
             # Set up mock objs
             workload_id = 19
             m_datastore_client.profile_exists.return_value = True
@@ -105,18 +109,18 @@ class NetworkPluginTest(unittest.TestCase):
             m_datastore_client.remove_profile(profile_name)
 
     def test_configure_interface(self):
-        with patch.object(self.plugin, '_read_docker_ip',
+        with patch_object(self.plugin, '_read_docker_ip',
                     autospec=True) as m_read_docker_ip, \
-                patch.object(self.plugin, '_get_container_pid', autospec=True) as m_get_container_pid, \
-                patch.object(self.plugin, '_delete_docker_interface',
+                patch_object(self.plugin, '_get_container_pid', autospec=True) as m_get_container_pid, \
+                patch_object(self.plugin, '_delete_docker_interface',
                     autospec=True) as m_delete_docker_interface, \
-                patch.object(self.plugin, '_container_add',
+                patch_object(self.plugin, '_container_add',
                     autospec=True) as m_container_add, \
-                patch.object(calico_kubernetes, 'generate_cali_interface_name',
+                patch_object(calico_kubernetes, 'generate_cali_interface_name',
                     autospec=True) as m_generate_cali_interface_name, \
-                patch.object(self.plugin, '_get_node_ip',
+                patch_object(self.plugin, '_get_node_ip',
                     autospec=True) as m_get_node_ip, \
-                patch.object(calico_kubernetes, 'check_call',
+                patch_object(calico_kubernetes, 'check_call',
                     autospec=True) as m_check_call:
             # Set up mock objects
             m_get_container_pid.return_value = 'container_pid'
@@ -149,12 +153,12 @@ class NetworkPluginTest(unittest.TestCase):
 
 
     def test_container_add(self):
-        with patch.object(self.plugin, '_datastore_client',
+        with patch_object(self.plugin, '_datastore_client',
                 autospec=True) as m_datastore_client,\
-            patch.object(self.plugin, '_validate_container_state',
+            patch_object(self.plugin, '_validate_container_state',
                 autospec=True) as m_validate_container_state, \
             patch('calico_kubernetes.calico_kubernetes.netns.PidNamespace', autospec=True) as m_pid_ns,\
-            patch.object(self.plugin, '_read_docker_ip', autospec=True) as m_read_docker_ip:
+            patch_object(self.plugin, '_read_docker_ip', autospec=True) as m_read_docker_ip:
             # Set up mock objs
             m_datastore_client.get_endpoint.side_effect = KeyError
             endpoint = Endpoint(TEST_HOST, TEST_ORCH_ID, '1234', '5678',
@@ -193,7 +197,7 @@ class NetworkPluginTest(unittest.TestCase):
 
         Expect system exit.
         """
-        with patch.object(self.plugin, '_datastore_client',
+        with patch_object(self.plugin, '_datastore_client',
                 autospec=True) as m_datastore_client:
             # Set up arguments
             container_name = 'container_name'
@@ -207,7 +211,7 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertRaises(SystemExit, self.plugin._container_add, pid, interface)
 
     def test_container_remove(self):
-        with patch.object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client,\
+        with patch_object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client,\
             patch('calico_kubernetes.calico_kubernetes.netns.remove_veth', autospec=True) as m_remove_veth:
             #Set up mock objs
             endpoint = Endpoint(TEST_HOST, TEST_ORCH_ID, '1234', '5678',
@@ -241,7 +245,7 @@ class NetworkPluginTest(unittest.TestCase):
 
         Expect a system exit
         """
-        with patch.object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
+        with patch_object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
             m_datastore_client.get_endpoint.side_effect = KeyError
 
             # Set up arguments
@@ -252,7 +256,7 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertRaises(SystemExit, self.plugin._container_remove)
 
     def test_validate_container_state(self):
-        with patch.object(self.plugin, '_get_container_info', autospec=True) as m_get_container_info:
+        with patch_object(self.plugin, '_get_container_info', autospec=True) as m_get_container_info:
             # Set up mock objs
             info_dict = {'State': {'Running': 1}, 'HostConfig': {'NetworkMode': ''}}
             m_get_container_info.return_value = info_dict
@@ -271,7 +275,7 @@ class NetworkPluginTest(unittest.TestCase):
 
         Expect system exit
         """
-        with patch.object(self.plugin, '_get_container_info', autospec=True) as m_get_container_info:
+        with patch_object(self.plugin, '_get_container_info', autospec=True) as m_get_container_info:
             # Set up mock objs
             info_dict = {'State': {'Running': 0}, 'HostConfig': {'NetworkMode': ''}}
             m_get_container_info.return_value = info_dict
@@ -286,7 +290,7 @@ class NetworkPluginTest(unittest.TestCase):
 
         Expect system exit
         """
-        with patch.object(self.plugin, '_get_container_info', autospec=True) as m_get_container_info:
+        with patch_object(self.plugin, '_get_container_info', autospec=True) as m_get_container_info:
             # Set up mock objs
             info_dict = {'State': {'Running': 1}, 'HostConfig': {'NetworkMode': 'host'}}
             m_get_container_info.return_value = info_dict
@@ -296,7 +300,7 @@ class NetworkPluginTest(unittest.TestCase):
                               'container_name')
 
     def test_get_container_info(self):
-        with patch.object(self.plugin, '_docker_client', autospec=True) as m_docker_client:
+        with patch_object(self.plugin, '_docker_client', autospec=True) as m_docker_client:
             # Set up args
             container_name = 'container_name'
 
@@ -307,7 +311,7 @@ class NetworkPluginTest(unittest.TestCase):
             m_docker_client.inspect_container.assert_called_once_with(container_name)
 
     def test_get_container_info_docker_api_error(self):
-        with patch.object(self.plugin, '_docker_client', autospec=True) as m_docker_client:
+        with patch_object(self.plugin, '_docker_client', autospec=True) as m_docker_client:
             # Create mock side effect APIError
             m_docker_client.inspect_container.side_effect = APIError('Error', Mock())
 
@@ -318,7 +322,7 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertRaises(SystemExit, self.plugin._get_container_info, container_name)
 
     def test_get_container_pid(self):
-        with patch.object(self.plugin, '_get_container_info', autospec=True) as m_get_container_info:
+        with patch_object(self.plugin, '_get_container_info', autospec=True) as m_get_container_info:
             # Set up args
             container_name = 'container_name'
 
@@ -356,7 +360,7 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertRaises(SystemExit, self.plugin._get_node_ip)
 
     def test_read_docker_ip(self):
-        with patch.object(self.plugin, '_get_container_info',
+        with patch_object(self.plugin, '_get_container_info',
                           autospec=True) as m_get_container_info:
             # Set up mock objects
             m_get_container_info.return_value = {'NetworkSettings': {'IPAddress': '1.2.3.4'}}
@@ -369,9 +373,9 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertEqual(return_val, IPAddress('1.2.3.4'))
 
     def test_delete_docker_interface(self):
-        with patch.object(calico_kubernetes, 'check_output',
+        with patch_object(calico_kubernetes, 'check_output',
                           autospec=True) as m_check_output,\
-                patch.object(self.plugin, '_get_container_pid', autospec=True) as m_get_container_pid:
+                patch_object(self.plugin, '_get_container_pid', autospec=True) as m_get_container_pid:
             # Set up mock objects
             m_get_container_pid.return_value = 'pid'
 
@@ -388,15 +392,15 @@ class NetworkPluginTest(unittest.TestCase):
             ], any_order=True)
 
     def test_configure_profile(self):
-        with patch.object(self.plugin, '_datastore_client',
+        with patch_object(self.plugin, '_datastore_client',
                     autospec=True) as m_datastore_client, \
-                patch.object(self.plugin, '_get_namespace_tag',
+                patch_object(self.plugin, '_get_namespace_tag',
                     autospec=True) as m_get_namespace_tag, \
-                patch.object(self.plugin, '_get_pod_config',
+                patch_object(self.plugin, '_get_pod_config',
                     autospec=True) as m_get_pod_config, \
-                patch.object(self.plugin, '_apply_rules',
+                patch_object(self.plugin, '_apply_rules',
                     autospec=True) as m_apply_rules, \
-                patch.object(self.plugin, '_apply_tags',
+                patch_object(self.plugin, '_apply_tags',
                     autospec=True) as m_apply_tags:
             # Set up mock objects
             m_datastore_client.profile_exists.return_value = False
@@ -431,9 +435,9 @@ class NetworkPluginTest(unittest.TestCase):
 
         Expect system exit.
         """
-        with patch.object(self.plugin, '_datastore_client',
+        with patch_object(self.plugin, '_datastore_client',
                     autospec=True) as m_datastore_client, \
-                patch.object(self.plugin, '_get_pod_config',
+                patch_object(self.plugin, '_get_pod_config',
                     autospec=True) as m_get_pod_config:
             # Set up mock objects
             m_datastore_client.profile_exists.return_value = True
@@ -485,7 +489,7 @@ class NetworkPluginTest(unittest.TestCase):
         self.assertListEqual(return_val, ports)
 
     def test_get_pod_config(self):
-        with patch.object(self.plugin, '_get_api_path',
+        with patch_object(self.plugin, '_get_api_path',
                     autospec=True) as m_get_api_path:
             # Set up mock object
             pod1 = {'metadata': {'namespace': 'a', 'name': 'pod-1'}}
@@ -505,7 +509,7 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertEqual(return_val, pod2)
 
     def test_get_pod_config_error(self):
-        with patch.object(self.plugin, '_get_api_path',
+        with patch_object(self.plugin, '_get_api_path',
                     autospec=True) as m_get_api_path:
             # Set up mock object and class members
             pod1 = {'metadata': {'name': 'pod-1'}}
@@ -522,11 +526,11 @@ class NetworkPluginTest(unittest.TestCase):
                 self.plugin._get_pod_config()
 
     def test_get_api_path(self):
-        with patch.object(self.plugin, '_get_api_token',
+        with patch_object(self.plugin, '_get_api_token',
                     autospec=True) as m_api_token, \
                 patch('calico_kubernetes.calico_kubernetes.requests.Session',
                     autospec=True) as m_session, \
-                patch.object(json, 'loads', autospec=True) as m_json_load:
+                patch_object(json, 'loads', autospec=True) as m_json_load:
             # Set up mock objects
             m_api_token.return_value = 'Token'
             m_session_return = Mock()
@@ -554,7 +558,7 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_get_api_token(self):
         with patch('__builtin__.open', autospec=True) as m_open, \
-                patch.object(json, 'loads', autospec=True) as m_json:
+                patch_object(json, 'loads', autospec=True) as m_json:
             # Set up mock objects
             m_open().__enter__().read.return_value = 'json_string'
             m_open.reset_mock()
@@ -575,7 +579,7 @@ class NetworkPluginTest(unittest.TestCase):
         Assert that the method returns an empty string
         """
         with patch('__builtin__.open', autospec=True) as m_open, \
-                patch.object(json, 'loads', autospec=True) as m_json:
+                patch_object(json, 'loads', autospec=True) as m_json:
             # Set up mock objects
             m_open.side_effect = IOError
             m_json.return_value = {'BearerToken' : 'correct_return'}
@@ -597,11 +601,11 @@ class NetworkPluginTest(unittest.TestCase):
         self.assertEqual(return_val, ([["allow"]], [["allow"]]))
 
     def test_apply_rules(self):
-        with patch.object(self.plugin, '_generate_rules',
+        with patch_object(self.plugin, '_generate_rules',
                     autospec=True) as m_generate_rules, \
-                patch.object(self.plugin, '_datastore_client',
+                patch_object(self.plugin, '_datastore_client',
                     autospec=True) as m_datastore_client, \
-                patch.object(self.plugin, 'calicoctl',
+                patch_object(self.plugin, 'calicoctl',
                     autospec=True) as m_calicoctl:
 
             # Set up mock objects
@@ -628,12 +632,12 @@ class NetworkPluginTest(unittest.TestCase):
             m_datastore_client.profile_update_rules(m_profile)
 
     def test_apply_rules_profile_not_found(self):
-        with patch.object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
+        with patch_object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
             m_datastore_client.get_profile.side_effect = KeyError
             self.assertRaises(SystemExit, self.plugin._apply_rules, 'profile')
 
     def test_apply_tags(self):
-        with patch.object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
+        with patch_object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
             # Intialize args
             pod = {'metadata': {'namespace': 'a', 'labels': {1: 2, "2/3": "4_5"}}}
             self.plugin.namespace = pod['metadata']['namespace']
@@ -658,7 +662,7 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertEqual(m_profile.tags, check_tags)
 
     def test_apply_tags_no_labels(self):
-        with patch.object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
+        with patch_object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
             # Intialize args
             pod = {}
             self.plugin.profile_name = 'profile_name'
@@ -671,7 +675,7 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertFalse(m_datastore_client.called)
 
     def test_apply_tags_profile_not_found(self):
-        with patch.object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
+        with patch_object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client:
             # Intialize args
             pod = {'metadata': {'labels': {1: 1, 2: 2}}}
             profile_name = 'profile_name'

--- a/calico_kubernetes/tests/kube_plugin_test.py
+++ b/calico_kubernetes/tests/kube_plugin_test.py
@@ -42,9 +42,9 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_create(self):
         with patch_object(self.plugin, '_configure_interface',
-                    autospec=True) as m_configure_interface, \
+                          autospec=True) as m_configure_interface, \
                 patch_object(self.plugin, '_configure_profile',
-                    autospec=True) as m_configure_profile:
+                             autospec=True) as m_configure_profile:
             # Set up mock objects
             m_configure_interface.return_value = 'endpt_id'
 
@@ -67,7 +67,7 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_create_error(self):
         with patch_object(self.plugin, '_configure_interface',
-                    autospec=True) as m_configure_interface, \
+                          autospec=True) as m_configure_interface, \
                 patch('sys.exit', autospec=True) as m_sys_exit:
             # Set up mock objects
             m_configure_interface.side_effect = CalledProcessError(1,'','')
@@ -110,18 +110,18 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_configure_interface(self):
         with patch_object(self.plugin, '_read_docker_ip',
-                    autospec=True) as m_read_docker_ip, \
+                          autospec=True) as m_read_docker_ip, \
                 patch_object(self.plugin, '_get_container_pid', autospec=True) as m_get_container_pid, \
                 patch_object(self.plugin, '_delete_docker_interface',
-                    autospec=True) as m_delete_docker_interface, \
+                             autospec=True) as m_delete_docker_interface, \
                 patch_object(self.plugin, '_container_add',
-                    autospec=True) as m_container_add, \
+                             autospec=True) as m_container_add, \
                 patch_object(calico_kubernetes, 'generate_cali_interface_name',
-                    autospec=True) as m_generate_cali_interface_name, \
+                             autospec=True) as m_generate_cali_interface_name, \
                 patch_object(self.plugin, '_get_node_ip',
-                    autospec=True) as m_get_node_ip, \
+                             autospec=True) as m_get_node_ip, \
                 patch_object(calico_kubernetes, 'check_call',
-                    autospec=True) as m_check_call:
+                             autospec=True) as m_check_call:
             # Set up mock objects
             m_get_container_pid.return_value = 'container_pid'
             m_read_docker_ip.return_value = IPAddress('1.1.1.1')
@@ -148,17 +148,17 @@ class NetworkPluginTest(unittest.TestCase):
             m_get_node_ip.assert_called_once_with()
             m_check_call.assert_called_once_with(
                 ['ip', 'addr', 'add', '1.2.3.4' + '/32',
-                'dev', 'interface_name'])
+                 'dev', 'interface_name'])
             self.assertEqual(return_val, endpoint)
 
 
     def test_container_add(self):
         with patch_object(self.plugin, '_datastore_client',
-                autospec=True) as m_datastore_client,\
-            patch_object(self.plugin, '_validate_container_state',
-                autospec=True) as m_validate_container_state, \
-            patch('calico_kubernetes.calico_kubernetes.netns.PidNamespace', autospec=True) as m_pid_ns,\
-            patch_object(self.plugin, '_read_docker_ip', autospec=True) as m_read_docker_ip:
+                          autospec=True) as m_datastore_client, \
+                patch_object(self.plugin, '_validate_container_state',
+                             autospec=True) as m_validate_container_state, \
+                patch('calico_kubernetes.calico_kubernetes.netns.PidNamespace', autospec=True) as m_pid_ns, \
+                patch_object(self.plugin, '_read_docker_ip', autospec=True) as m_read_docker_ip:
             # Set up mock objs
             m_datastore_client.get_endpoint.side_effect = KeyError
             endpoint = Endpoint(TEST_HOST, TEST_ORCH_ID, '1234', '5678',
@@ -198,7 +198,7 @@ class NetworkPluginTest(unittest.TestCase):
         Expect system exit.
         """
         with patch_object(self.plugin, '_datastore_client',
-                autospec=True) as m_datastore_client:
+                          autospec=True) as m_datastore_client:
             # Set up arguments
             container_name = 'container_name'
             workload_id = 'workload_id'
@@ -211,8 +211,8 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertRaises(SystemExit, self.plugin._container_add, pid, interface)
 
     def test_container_remove(self):
-        with patch_object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client,\
-            patch('calico_kubernetes.calico_kubernetes.netns.remove_veth', autospec=True) as m_remove_veth:
+        with patch_object(self.plugin, '_datastore_client', autospec=True) as m_datastore_client, \
+                patch('calico_kubernetes.calico_kubernetes.netns.remove_veth', autospec=True) as m_remove_veth:
             #Set up mock objs
             endpoint = Endpoint(TEST_HOST, TEST_ORCH_ID, '1234', '5678',
                                 'active', 'mac')
@@ -374,7 +374,7 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_delete_docker_interface(self):
         with patch_object(calico_kubernetes, 'check_output',
-                          autospec=True) as m_check_output,\
+                          autospec=True) as m_check_output, \
                 patch_object(self.plugin, '_get_container_pid', autospec=True) as m_get_container_pid:
             # Set up mock objects
             m_get_container_pid.return_value = 'pid'
@@ -393,15 +393,15 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_configure_profile(self):
         with patch_object(self.plugin, '_datastore_client',
-                    autospec=True) as m_datastore_client, \
+                          autospec=True) as m_datastore_client, \
                 patch_object(self.plugin, '_get_namespace_tag',
-                    autospec=True) as m_get_namespace_tag, \
+                             autospec=True) as m_get_namespace_tag, \
                 patch_object(self.plugin, '_get_pod_config',
-                    autospec=True) as m_get_pod_config, \
+                             autospec=True) as m_get_pod_config, \
                 patch_object(self.plugin, '_apply_rules',
-                    autospec=True) as m_apply_rules, \
+                             autospec=True) as m_apply_rules, \
                 patch_object(self.plugin, '_apply_tags',
-                    autospec=True) as m_apply_tags:
+                             autospec=True) as m_apply_tags:
             # Set up mock objects
             m_datastore_client.profile_exists.return_value = False
             m_get_pod_config.return_value = 'pod'
@@ -436,9 +436,9 @@ class NetworkPluginTest(unittest.TestCase):
         Expect system exit.
         """
         with patch_object(self.plugin, '_datastore_client',
-                    autospec=True) as m_datastore_client, \
+                          autospec=True) as m_datastore_client, \
                 patch_object(self.plugin, '_get_pod_config',
-                    autospec=True) as m_get_pod_config:
+                             autospec=True) as m_get_pod_config:
             # Set up mock objects
             m_datastore_client.profile_exists.return_value = True
             m_get_pod_config.return_value = 'pod'
@@ -490,7 +490,7 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_get_pod_config(self):
         with patch_object(self.plugin, '_get_api_path',
-                    autospec=True) as m_get_api_path:
+                          autospec=True) as m_get_api_path:
             # Set up mock object
             pod1 = {'metadata': {'namespace': 'a', 'name': 'pod-1'}}
             pod2 = {'metadata': {'namespace': 'a', 'name': 'pod-2'}}
@@ -510,7 +510,7 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_get_pod_config_error(self):
         with patch_object(self.plugin, '_get_api_path',
-                    autospec=True) as m_get_api_path:
+                          autospec=True) as m_get_api_path:
             # Set up mock object and class members
             pod1 = {'metadata': {'name': 'pod-1'}}
             pod2 = {'metadata': {'name': 'pod-2'}}
@@ -527,9 +527,9 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_get_api_path(self):
         with patch_object(self.plugin, '_get_api_token',
-                    autospec=True) as m_api_token, \
+                          autospec=True) as m_api_token, \
                 patch('calico_kubernetes.calico_kubernetes.requests.Session',
-                    autospec=True) as m_session, \
+                      autospec=True) as m_session, \
                 patch_object(json, 'loads', autospec=True) as m_json_load:
             # Set up mock objects
             m_api_token.return_value = 'Token'
@@ -602,11 +602,11 @@ class NetworkPluginTest(unittest.TestCase):
 
     def test_apply_rules(self):
         with patch_object(self.plugin, '_generate_rules',
-                    autospec=True) as m_generate_rules, \
+                          autospec=True) as m_generate_rules, \
                 patch_object(self.plugin, '_datastore_client',
-                    autospec=True) as m_datastore_client, \
+                             autospec=True) as m_datastore_client, \
                 patch_object(self.plugin, 'calicoctl',
-                    autospec=True) as m_calicoctl:
+                             autospec=True) as m_calicoctl:
 
             # Set up mock objects
             m_profile = Mock()
@@ -627,7 +627,7 @@ class NetworkPluginTest(unittest.TestCase):
                 call('profile', profile_name, 'rule', 'remove', 'inbound', '--at=2'),
                 call('profile', profile_name, 'rule', 'remove', 'inbound', '--at=1'),
                 call('profile', profile_name, 'rule', 'remove', 'outbound', '--at=1')
-                ])
+            ])
             m_generate_rules.assert_called_once_with(pod)
             m_datastore_client.profile_update_rules(m_profile)
 


### PR DESCRIPTION
Previously we were not logging the state of the pod infra
container's namespace during our modifications, which make it
impossible to diagnose issues with these steps.

Add some verbose debug logging to show the interface state
on the machine before and after we configure the pod namespace.