### PR TITLE
Service account auth

### DIFF
--- a/calico_kubernetes/tests/kube_plugin_test.py
+++ b/calico_kubernetes/tests/kube_plugin_test.py
@@ -547,33 +547,33 @@ class NetworkPluginTest(unittest.TestCase):
             with self.assertRaises(KeyError):
                 self.plugin._get_pod_config()
 
-    def test_get_api_path(self):
-        with patch('calico_kubernetes.calico_kubernetes.requests.Session',
-                   autospec=True) as m_session, \
-                patch('json.loads', autospec=True) as m_json_load:
-            # Set up mock objects
-            self.plugin.auth_token = 'TOKEN'
-            m_session_return = Mock()
-            m_session_return.headers = Mock()
-            m_get_return = Mock()
-            m_get_return.text = 'response_body'
-            m_session_return.get.return_value = m_get_return
-            m_session.return_value = m_session_return
+    @patch('calico_kubernetes.calico_kubernetes.requests.Session',
+           autospec=True)
+    @patch('json.loads', autospec=True)
+    def test_get_api_path(self, m_json_load, m_session):
+        # Set up mock objects
+        self.plugin.auth_token = 'TOKEN'
+        m_session_return = Mock()
+        m_session_return.headers = Mock()
+        m_get_return = Mock()
+        m_get_return.text = 'response_body'
+        m_session_return.get.return_value = m_get_return
+        m_session.return_value = m_session_return
 
-            # Initialize args
-            path = 'path/to/api/object'
+        # Initialize args
+        path = 'path/to/api/object'
 
-            # Call method under test
-            self.plugin._get_api_path(path)
+        # Call method under test
+        self.plugin._get_api_path(path)
 
-            # Assert
-            m_session.assert_called_once_with()
-            m_session_return.headers.update.assert_called_once_with(
-                {'Authorization': 'Bearer ' + 'TOKEN'})
-            m_session_return.get.assert_called_once_with(
-                calico_kubernetes.KUBE_API_ROOT + 'path/to/api/object',
-                verify=False)
-            m_json_load.assert_called_once_with('response_body')
+        # Assert
+        m_session.assert_called_once_with()
+        m_session_return.headers.update.assert_called_once_with(
+            {'Authorization': 'Bearer ' + 'TOKEN'})
+        m_session_return.get.assert_called_once_with(
+            calico_kubernetes.KUBE_API_ROOT + 'path/to/api/object',
+            verify=False)
+        m_json_load.assert_called_once_with('response_body')
 
     def test_generate_rules(self):
         pod = {'metadata': {'profile': 'name'}}

--- a/calico_kubernetes/tests/kube_plugin_test.py
+++ b/calico_kubernetes/tests/kube_plugin_test.py
@@ -11,30 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 
-import json
 import unittest
 from mock import patch, Mock, call
 from netaddr import IPAddress, IPNetwork
 from subprocess import CalledProcessError
 from docker.errors import APIError
 from nose.tools import assert_equal
-from nose_parameterized import param
 from calico_kubernetes import calico_kubernetes
 from pycalico.datastore import IF_PREFIX
 from pycalico.datastore_datatypes import Profile, Endpoint
 from pycalico.block import AlreadyAssignedError
 from nose.tools import assert_true
 
+# noinspection PyProtectedMember
 from calico_kubernetes.calico_kubernetes import _log_interfaces
 
 # noinspection PyUnresolvedReferences
 patch_object = patch.object
 
-
 TEST_HOST = calico_kubernetes.HOSTNAME
 TEST_ORCH_ID = calico_kubernetes.ORCHESTRATOR_ID
 
+_log = logging.getLogger(__name__)
 
 
 class NetworkPluginTest(unittest.TestCase):
@@ -483,7 +483,6 @@ class NetworkPluginTest(unittest.TestCase):
             m_datastore_client.profile_exists.assert_called_once_with(profile_name)
             self.assertFalse(m_datastore_client.create_profile.called)
 
-
     def test_get_pod_ports(self):
         # Initialize pod dictionary and expected outcome
         pod = {'spec': {'containers': [{'ports': [1, 2, 3]},{'ports': [4, 5]}]}}
@@ -706,8 +705,9 @@ class NetworkPluginTest(unittest.TestCase):
            'calico_kubernetes.configure_logger', autospec=True)
     def test_run_protected_sys_exit(self, _, m_run, m_sys_exit):
         for exception_cls in (SystemExit, RuntimeError):
+            _log.info('Testing that we handle %s exceptions',
+                      str(exception_cls.__name__))
             m_run.side_effect = exception_cls
-
             calico_kubernetes.run_protected()
 
             # Check we actually called the work function.


### PR DESCRIPTION
Previously we extracted the Bearer token (used for authenticating
with the kube-apiserver) from the basic auth file. This auth
method is deprecated, so we should instead support the
more generic Service Account tokens.

Both mechanisms use the HTTP "Authentication: Bearer" header,
so all this commit changes is where we get that token from; now
we use the AUTH_TOKEN environment variable.