### PR TITLE
Skip `if __name__ == '__main__'` in coverage

### DIFF
--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -844,5 +844,5 @@ def run():
                 NetworkPlugin().delete(namespace, pod_name, docker_id)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     run_protected()


### PR DESCRIPTION
It's not easy to test the entry point to our plugin, so skip that
line in UTs. Everything will break if this isn't working, so
assume that FV/e2e tests will catch issues here.