### PR TITLE
Only configure stdout logging in setup and teardown hooks

### DIFF
--- a/build_calico_kubernetes/requirements.txt
+++ b/build_calico_kubernetes/requirements.txt
@@ -1,5 +1,5 @@
 PyInstaller==2.1
-git+https://github.com/projectcalico/libcalico.git@v0.2.0
+git+https://github.com/projectcalico/libcalico.git@v0.3.1
 sh==1.11
 coverage==3.7.1
 nose==1.3.1

--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -26,7 +26,7 @@ import socket
 
 from docker import Client
 from docker.errors import APIError
-from logutils import configure_logger
+from logutils import configure_logger, configure_stdout_logger
 from netaddr import IPAddress, IPNetwork, AddrFormatError
 from policy import PolicyParser
 from subprocess import check_output, CalledProcessError, check_call
@@ -767,6 +767,12 @@ def run():
             logger.info('Executing Calico pod-status hook')
             NetworkPlugin().status(namespace, pod_name, docker_id)
         else:
+            # Append an stdout logging handler to log to the Kubelet
+            # We cannot do this in status hook because K8 looks to stdout
+            # for status results.
+            configure_stdout_logger(logger, logging.INFO, True)
+            configure_stdout_logger(pycalico_logger, logging.INFO, False)
+
             logger.info("Using LOG_LEVEL=%s", LOG_LEVEL)
             logger.info("Using ETCD_AUTHORITY=%s",
                         os.environ[ETCD_AUTHORITY_ENV])

--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -767,9 +767,9 @@ def run():
             logger.info('Executing Calico pod-status hook')
             NetworkPlugin().status(namespace, pod_name, docker_id)
         else:
-            # Append an stdout logging handler to log to the Kubelet
-            # We cannot do this in status hook because K8 looks to stdout
-            # for status results.
+            # Append a stdout logging handler to log to the Kubelet.
+            # We cannot do this in the status hook because the Kubelet looks to
+            # stdout for status results.
             configure_stdout_logger(logger, logging.INFO, True)
             configure_stdout_logger(pycalico_logger, logging.INFO, False)
 

--- a/calico_kubernetes/logutils.py
+++ b/calico_kubernetes/logutils.py
@@ -30,8 +30,6 @@ def configure_logger(logger, log_level, root_logger=False, log_dir=LOG_DIR):
     file_hdlr = logging.handlers.RotatingFileHandler(filename=log_dir+'calico.log',
                                                      maxBytes=10000000,
                                                      backupCount=5)
-    stdout_hdlr = logging.StreamHandler(sys.stdout)
-    stdout_hdlr.setLevel(logging.INFO)
 
     # Determine which formatter to use.
     if root_logger:
@@ -41,8 +39,30 @@ def configure_logger(logger, log_level, root_logger=False, log_dir=LOG_DIR):
 
     # Set formatters on handlers
     file_hdlr.setFormatter(formatter)
-    stdout_hdlr.setFormatter(formatter)
 
     logger.addHandler(file_hdlr)
-    logger.addHandler(stdout_hdlr)
     logger.setLevel(log_level)
+
+def configure_stdout_logger(logger, log_level=logging.INFO, root_logger=False):
+    """
+    Configure an stdout logging handler to the logger
+
+    If a log level is not indicated use the logger's current logging level
+
+    :param logger:  logger object to configure
+    :param log_level: log_level: level at which logger starts logging.
+    :return:
+    """
+    # Determine which formatter to use.
+    if root_logger:
+        formatter = logging.Formatter(ROOT_LOG_FORMAT)
+    else:
+        formatter = logging.Formatter(LOG_FORMAT)
+
+    # Create the handler and apply attributes
+    stdout_hdlr = logging.StreamHandler(sys.stdout)
+    stdout_hdlr.setLevel(log_level)
+    stdout_hdlr.setFormatter(formatter)
+
+    # Add handler to the logger object
+    logger.addHandler(stdout_hdlr)


### PR DESCRIPTION
Fix to issue #79 

Also includes bumping libcalico to the correct version that supports specifying rules at profile creation