### PR TITLE
Validation status fix + API access improvements

### DIFF
--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -151,7 +151,7 @@ class NetworkPlugin(object):
             # for them.
             logger.debug("Ignoring status for pod %s/%s in host namespace",
                          self.namespace, self.pod_name)
-            sys.exit(1)
+            sys.exit(0)
 
         # Find the endpoint
         try:
@@ -429,9 +429,9 @@ class NetworkPlugin(object):
 
         # We can't set up Calico if the container shares the host namespace.
         if info["HostConfig"]["NetworkMode"] == "host":
-            logger.error("Can't add the container to Calico because "
-                         "it is running NetworkMode = host.")
-            sys.exit(1)
+            logger.warning("Calico cannot network container because "
+                           "it is running NetworkMode = host.")
+            sys.exit(0)
 
     def _uses_host_networking(self, container_name):
         """
@@ -875,8 +875,8 @@ def run_protected():
     except SystemExit, e:
         # If a SystemExit is thrown, we've already handled the error and have
         # called sys.exit().  No need to produce a duplicate exception
-        # message, just set the return code to 1.
-        rc = e.code
+        # message, just return the exit code.
+        rc = e
     except BaseException:
         # Log the exception and set the return code to 1.
         logger.exception("Unhandled Exception killed plugin")

--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -535,6 +535,7 @@ class NetworkPlugin(object):
         """
         with requests.Session() as session:
             if self._api_root_secure() and self.auth_token:
+                logger.debug('Updating header with Token %s', self.auth_token)
                 session.headers.update({'Authorization':
                                         'Bearer ' + self.auth_token})
 
@@ -542,7 +543,7 @@ class NetworkPlugin(object):
                                 'namespaces/%s/pods/%s' % (self.namespace,
                                                            self.pod_name))
             try:
-                logger.debug('Fetching API Resource from %s', path)
+                logger.debug('Querying API for Pod: %s', path)
                 response = session.get(path, verify=False)
             except BaseException:
                 logger.exception("Exception hitting Kubernetes API")
@@ -566,8 +567,10 @@ class NetworkPlugin(object):
         :return: Boolean: True if secure. False if insecure
         """
         if (self.api_root[:5] == 'https'):
+            logger.debug('Using Secure API access.')
             return True
         elif (self.api_root[:5] == 'http:'):
+            logger.debug('Using Insecure API access.')
             return False
         else:
             logger.error('%s is not set correctly (%s). '


### PR DESCRIPTION
+ Contains #89 
+ Host ns containers are not managed by Calico, but the kubelet will still use the plugin. This ensures that Calico does not fail setup/status calls. 
+ Improve api access in `get_pod_config`