### PR TITLE
Get configuration from on-disk file.

### DIFF
--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -768,10 +768,6 @@ def read_config_file():
     cur_dir = os.path.dirname(executable)
     config_file = os.path.join(cur_dir, CONFIG_FILENAME)
 
-    # Check that the file exists.
-    if not os.path.isfile(config_file):
-        sys.exit("Cannot find configuration file: %s" % config_file)
-
     # Create dictionary of default values.
     defaults = {
         ETCD_AUTHORITY_VAR: "127.0.0.1:2379",
@@ -782,6 +778,10 @@ def read_config_file():
         LOG_LEVEL_VAR: "INFO",
     }
     config = {}
+
+    # Check that the file exists.  If not, return default values.
+    if not os.path.isfile(config_file):
+        return defaults
 
     # Read the config file.
     parser = ConfigParser.ConfigParser(defaults)

--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -23,6 +23,7 @@ import logging
 import sys
 import json
 import socket
+import ConfigParser
 
 from docker import Client
 from docker.errors import APIError
@@ -43,39 +44,40 @@ from logutils import *
 
 pycalico_logger = logging.getLogger(pycalico.__name__)
 logger = logging.getLogger(__name__)
-LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO').upper()
 
 DOCKER_VERSION = "1.16"
 ORCHESTRATOR_ID = "docker"
 HOSTNAME = socket.gethostname()
 
+# Config filename.
+CONFIG_FILENAME = "calico_kubernetes.ini"
+
 POLICY_ANNOTATION_KEY = "projectcalico.org/policy"
 
-ETCD_AUTHORITY_ENV = "ETCD_AUTHORITY"
-if ETCD_AUTHORITY_ENV not in os.environ:
-    os.environ[ETCD_AUTHORITY_ENV] = 'kubernetes-master:6666'
-
-KUBE_API_ROOT = os.environ.get('KUBE_API_ROOT',
-                               'http://kubernetes-master:8080/api/v1/')
-
-# Allow the user to enable/disable namespace isolation policy
-DEFAULT_POLICY = os.environ.get('DEFAULT_POLICY', 'allow')
-
-# Flag to indicate whether or not to use Calico IPAM.
-# If "false", use the default docker container ip address to create container.
-# If "true", use libcalico's auto_assign IPAM to create container.
-CALICO_IPAM = os.environ.get('CALICO_IPAM', 'true').lower()
+# Values in configuration dictionary
+ETCD_AUTHORITY_VAR = "ETCD_AUTHORITY"
+LOG_LEVEL_VAR = "LOG_LEVEL"
+KUBE_AUTH_TOKEN_VAR = "KUBE_AUTH_TOKEN"
+KUBE_API_ROOT_VAR = "KUBE_API_ROOT"
+CALICO_IPAM_VAR = "CALICO_IPAM"
+DEFAULT_POLICY_VAR = "DEFAULT_POLICY"
 
 
 class NetworkPlugin(object):
 
-    def __init__(self):
+    def __init__(self, config):
         self.pod_name = None
         self.profile_name = None
         self.namespace = None
         self.docker_id = None
-        self.auth_token = os.environ.get('KUBE_AUTH_TOKEN', None)
         self.policy_parser = None
+
+        # Get configuration from the given dictionary.
+        logger.debug("Plugin running with config: %s", config)
+        self.auth_token = config[KUBE_AUTH_TOKEN_VAR]
+        self.api_root = config[KUBE_API_ROOT_VAR]
+        self.calico_ipam = config[CALICO_IPAM_VAR].lower()
+        self.default_policy = config[DEFAULT_POLICY_VAR].lower()
 
         self._datastore_client = IPAMClient()
         self._docker_client = Client(
@@ -290,8 +292,6 @@ class NetworkPlugin(object):
         Assign IPAddress either with the assigned docker IPAddress or utilize
         calico IPAM.
 
-        The option to utilize IPAM is indicated by the environment variable
-        "CALICO_IPAM".
         True indicates to utilize Calico's auto_assign IPAM policy.
         False indicate to utilize the docker assigned IPAddress
 
@@ -309,7 +309,7 @@ class NetworkPlugin(object):
                 logger.exception("Failed to assign IPAddress %s", ip)
                 sys.exit(1)
 
-        if CALICO_IPAM == 'true':
+        if self.calico_ipam == 'true':
             logger.info("Using Calico IPAM")
             try:
                 ipv4s, ipv6s = self._datastore_client.auto_assign_ips(1, 0,
@@ -526,13 +526,12 @@ class NetworkPlugin(object):
         :return: A list of JSON API objects
         :rtype list
         """
-        logger.info('Getting API Resource: %s from KUBE_API_ROOT: %s',
-                    path, KUBE_API_ROOT)
+        logger.info('Getting API Resource: %s%s', self.api_root, path)
         session = requests.Session()
         if self.auth_token:
             session.headers.update({'Authorization':
                                     'Bearer ' + self.auth_token})
-        response = session.get(KUBE_API_ROOT + path, verify=False)
+        response = session.get(self.api_root + path, verify=False)
         response_body = response.text
 
         # The response body contains some metadata, and the pods themselves
@@ -541,19 +540,19 @@ class NetworkPlugin(object):
 
     def _api_root_secure(self):
         """
-        Checks whether the KUBE_API_ROOT is secure or insecure.
+        Checks whether the Kubernetes api root is secure or insecure.
         If not an http or https address, exit.
 
         :return: Boolean: True if secure. False if insecure
         """
-        if (KUBE_API_ROOT[:5] == 'https'):
+        if (self.api_root[:5] == 'https'):
             return True
-        elif (KUBE_API_ROOT[:5] == 'http:'):
+        elif (self.api_root[:5] == 'http:'):
             return False
         else:
-            logger.error('KUBE_API_ROOT is not set correctly (%s). '
+            logger.error('%s is not set correctly (%s). '
                          'Please specify as http or https address. Exiting',
-                         KUBE_API_ROOT)
+                         KUBE_API_ROOT_VAR, self.api_root)
             sys.exit(1)
 
     def _generate_rules(self, pod):
@@ -587,7 +586,7 @@ class NetworkPlugin(object):
         else:
             # If not annotations are defined, just use the configured
             # default policy.
-            if DEFAULT_POLICY == 'ns_isolation':
+            if self.default_policy == 'ns_isolation':
                 # Isolate on namespace boundaries by default.
                 logger.debug("Default policy is namespace isolation")
                 inbound_rules = [allow_ns]
@@ -724,6 +723,84 @@ def _log_interfaces(namespace):
         # Don't exit if we hit an error logging out the interfaces.
         logger.exception("Ignoring error logging interfaces")
 
+
+def load_config():
+    """
+    Loads configuration for the plugin - returns a dictionary.
+
+    Looks first in environment, then in local config file.
+    """
+    # First, read the config file and get defaults.
+    config = read_config_file()
+
+    # Get config from environment.
+    env_config = {
+            CALICO_IPAM_VAR: os.environ.get(CALICO_IPAM_VAR),
+            KUBE_API_ROOT_VAR: os.environ.get(KUBE_API_ROOT_VAR),
+            DEFAULT_POLICY_VAR: os.environ.get(DEFAULT_POLICY_VAR),
+            KUBE_AUTH_TOKEN_VAR: os.environ.get(KUBE_AUTH_TOKEN_VAR),
+    }
+
+    # Environment variables take precedence.
+    for k,v in env_config.iteritems():
+        if v is not None:
+            logger.debug("Use env variable: %s=%s", k, v)
+            config[k] = v
+
+    # ETCD_AUTHORITY is handled slightly differently - we need to set it in the
+    # environment so that libcalico works correctly.
+    if not ETCD_AUTHORITY_VAR in os.environ:
+        logger.debug("Use env variable: %s=%s",
+                     ETCD_AUTHORITY_VAR,
+                     config[ETCD_AUTHORITY_VAR])
+        os.environ[ETCD_AUTHORITY_VAR] = config[ETCD_AUTHORITY_VAR]
+
+    return config
+
+
+def read_config_file():
+    """
+    Reads the config file on disk and returns configuration dictionary.
+    """
+    # Get the current directory and find path to config file.
+    executable = sys.argv[0]
+    cur_dir = os.path.dirname(executable)
+    config_file = os.path.join(cur_dir, CONFIG_FILENAME)
+
+    # Check that the file exists.
+    if not os.path.exists(config_file):
+        sys.exit("Cannot find configuration file: %s" % config_file)
+
+    # Create dictionary of default values.
+    defaults = {
+        ETCD_AUTHORITY_VAR: "127.0.0.1:2379",
+        CALICO_IPAM_VAR: "true",
+        KUBE_API_ROOT_VAR: "http://kubernetes-master:8080/api/v1",
+        DEFAULT_POLICY_VAR: "allow",
+        KUBE_AUTH_TOKEN_VAR: None,
+        LOG_LEVEL_VAR: "INFO",
+    }
+    config = {}
+
+    # Read the config file.
+    parser = ConfigParser.ConfigParser(defaults)
+    parser.read(config_file)
+
+    # Make sure the config section exists
+    if not "config" in parser.sections():
+        sys.exit("No [config] section in file %s" % config_file)
+
+    # Get any values from the configuration file and populate dictionary.
+    config[ETCD_AUTHORITY_VAR] = parser.get("config", ETCD_AUTHORITY_VAR)
+    config[CALICO_IPAM_VAR] = parser.get("config", CALICO_IPAM_VAR)
+    config[KUBE_API_ROOT_VAR] = parser.get("config", KUBE_API_ROOT_VAR)
+    config[DEFAULT_POLICY_VAR] = parser.get("config", DEFAULT_POLICY_VAR)
+    config[KUBE_AUTH_TOKEN_VAR] = parser.get("config", KUBE_AUTH_TOKEN_VAR)
+    config[LOG_LEVEL_VAR] = parser.get("config", LOG_LEVEL_VAR).upper()
+
+    return config
+
+
 def run_protected():
     """
     Runs the plugin, intercepting all exceptions.
@@ -735,6 +812,9 @@ def run_protected():
     pod_name = sys.argv[3].replace('/', '_') if len(sys.argv) >=4 else None
     docker_id = sys.argv[4] if len(sys.argv) >=5 else None
 
+    # Get config from file / environment.
+    config = load_config()
+
     # Append a stdout logging handler to log to the Kubelet.
     # We cannot do this in the status hook because the Kubelet looks to
     # stdout for status results.
@@ -744,11 +824,11 @@ def run_protected():
     # If docker_id is not supplied, do not include it in logger config.
     if docker_id:
         configure_logger(logger=logger,
-                         log_level=LOG_LEVEL,
+                         log_level=config[LOG_LEVEL_VAR],
                          log_format=DOCKER_ID_ROOT_LOG_FORMAT,
                          log_to_stdout=log_to_stdout)
         configure_logger(logger=pycalico_logger,
-                         log_level=LOG_LEVEL,
+                         log_level=config[LOG_LEVEL_VAR],
                          log_format=DOCKER_ID_LOG_FORMAT,
                          log_to_stdout=log_to_stdout)
 
@@ -757,11 +837,11 @@ def run_protected():
         pycalico_logger.addFilter(docker_filter)
     else:
         configure_logger(logger=logger,
-                         log_level=LOG_LEVEL,
+                         log_level=config[LOG_LEVEL_VAR],
                          log_format=ROOT_LOG_FORMAT,
                          log_to_stdout=log_to_stdout)
         configure_logger(logger=pycalico_logger,
-                         log_level=LOG_LEVEL,
+                         log_level=config[LOG_LEVEL_VAR],
                          log_format=LOG_FORMAT,
                          log_to_stdout=log_to_stdout)
 
@@ -773,7 +853,8 @@ def run_protected():
         run(mode=mode,
             namespace=namespace,
             pod_name=pod_name,
-            docker_id=docker_id)
+            docker_id=docker_id,
+            config=config)
     except SystemExit:
         # If a SystemExit is thrown, we've already handled the error and have
         # called sys.exit().  No need to produce a duplicate exception
@@ -788,28 +869,21 @@ def run_protected():
         logger.info("Calico network plugin execution complete")
         sys.exit(rc)
 
-def run(mode, namespace, pod_name, docker_id):
+
+def run(mode, namespace, pod_name, docker_id, config):
     if mode == 'init':
         logger.info('No initialization work to perform')
-    elif mode == "status":
-        # Status is called on a regular basis - handle separately
-        # to avoid flooding the logs.
-        logger.info('Executing Calico pod-status hook')
-        NetworkPlugin().status(namespace, pod_name, docker_id)
     else:
-        logger.info("Using LOG_LEVEL=%s", LOG_LEVEL)
-        logger.info("Using ETCD_AUTHORITY=%s",
-                    os.environ[ETCD_AUTHORITY_ENV])
-        logger.info("Using KUBE_API_ROOT=%s", KUBE_API_ROOT)
-        logger.info("Using CALICO_IPAM=%s", CALICO_IPAM)
-        logger.info("Using DEFAULT_POLICY=%s", DEFAULT_POLICY)
-
+        # Create the plugin instance, passing in config.
         if mode == 'setup':
             logger.info('Executing Calico pod-creation hook')
-            NetworkPlugin().create(namespace, pod_name, docker_id)
+            NetworkPlugin(config).create(namespace, pod_name, docker_id)
         elif mode == 'teardown':
             logger.info('Executing Calico pod-deletion hook')
-            NetworkPlugin().delete(namespace, pod_name, docker_id)
+            NetworkPlugin(config).delete(namespace, pod_name, docker_id)
+        elif mode == "status":
+            logger.debug('Executing Calico pod-status hook')
+            NetworkPlugin(config).status(namespace, pod_name, docker_id)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/calico_kubernetes/tests/kube_plugin_test.py
+++ b/calico_kubernetes/tests/kube_plugin_test.py
@@ -1309,5 +1309,15 @@ class NetworkPluginTest(unittest.TestCase):
         # Mock
         m_os.path.isfile.return_value = False
 
+        # Defaults
+        defaults = {
+            ETCD_AUTHORITY_VAR: "127.0.0.1:2379",
+            CALICO_IPAM_VAR: "true",
+            KUBE_API_ROOT_VAR: "http://kubernetes-master:8080/api/v1",
+            DEFAULT_POLICY_VAR: "allow",
+            KUBE_AUTH_TOKEN_VAR: None,
+            LOG_LEVEL_VAR: "INFO",
+        }
+
         # Call method under test
-        assert_raises(SystemExit, calico_kubernetes.read_config_file)
+        assert_equal(defaults, calico_kubernetes.read_config_file())

--- a/calico_kubernetes/tests/kube_plugin_test.py
+++ b/calico_kubernetes/tests/kube_plugin_test.py
@@ -16,6 +16,7 @@ import sys
 import json
 import logging
 import unittest
+import copy
 
 from docker.errors import APIError
 from mock import patch, Mock, MagicMock, call
@@ -31,6 +32,12 @@ from pycalico.datastore_datatypes import Profile, Endpoint
 
 # noinspection PyProtectedMember
 from calico_kubernetes.calico_kubernetes import _log_interfaces, POLICY_ANNOTATION_KEY
+from calico_kubernetes.calico_kubernetes import (KUBE_API_ROOT_VAR,
+                                                 CALICO_IPAM_VAR,
+                                                 KUBE_AUTH_TOKEN_VAR,
+                                                 ETCD_AUTHORITY_VAR,
+                                                 LOG_LEVEL_VAR,
+                                                 DEFAULT_POLICY_VAR)
 from calico_kubernetes.logutils import ROOT_LOG_FORMAT, LOG_FORMAT, DOCKER_ID_ROOT_LOG_FORMAT, DOCKER_ID_LOG_FORMAT
 
 # noinspection PyUnresolvedReferences
@@ -41,12 +48,21 @@ TEST_ORCH_ID = calico_kubernetes.ORCHESTRATOR_ID
 
 _log = logging.getLogger(__name__)
 
+CONFIG = {
+    KUBE_API_ROOT_VAR: "",
+    KUBE_AUTH_TOKEN_VAR: "",
+    CALICO_IPAM_VAR: "true",
+    ETCD_AUTHORITY_VAR: "",
+    LOG_LEVEL_VAR: "",
+    DEFAULT_POLICY_VAR: "",
+}
+
 
 class NetworkPluginTest(unittest.TestCase):
 
     def setUp(self):
         self.namespace = "testNamespace"
-        self.plugin = calico_kubernetes.NetworkPlugin()
+        self.plugin = calico_kubernetes.NetworkPlugin(CONFIG)
         self.plugin.namespace = self.namespace
         self.plugin.profile_name = "test_profile_name"
 
@@ -502,7 +518,7 @@ class NetworkPluginTest(unittest.TestCase):
         with patch.object(self.plugin, "_read_docker_ip") as m_read_ip:
 
             # Don't use CALICO_IPAM for this test.
-            calico_kubernetes.CALICO_IPAM = "false"
+            self.plugin.calico_ipam = "false"
 
             # Mock the Docker IP
             docker_ip = "172.12.23.4"
@@ -540,7 +556,7 @@ class NetworkPluginTest(unittest.TestCase):
         with patch.object(self.plugin, "_read_docker_ip") as m_read_ip:
 
             # Don't use CALICO_IPAM for this test.
-            calico_kubernetes.CALICO_IPAM = "false"
+            self.plugin.calico_ipam = "false"
 
             # Mock the Docker IP
             docker_ip = "172.12.23.4"
@@ -806,13 +822,15 @@ class NetworkPluginTest(unittest.TestCase):
         path = 'path/to/api/object'
 
         # Call method under test
+        api_root = "http://kubernetesapi:8080/api/v1"
+        self.plugin.api_root = api_root
         self.plugin._get_api_path(path)
 
         # Assert correct data in calls.
         m_session_return.headers.update.assert_called_once_with(
             {'Authorization': 'Bearer ' + 'TOKEN'})
         m_session_return.get.assert_called_once_with(
-            calico_kubernetes.KUBE_API_ROOT + 'path/to/api/object',
+            api_root + 'path/to/api/object',
             verify=False)
         m_json_load.assert_called_once_with('response_body')
 
@@ -894,32 +912,6 @@ class NetworkPluginTest(unittest.TestCase):
         # Assert return value is correct.
         assert_equal(return_val, expected)
 
-    def test_generate_rules_ns_iso(self):
-        """Test _generate_rules with ns_isolation
-
-        Test that ns_isolation is default policy when set.
-        """
-        pod = {
-                'metadata': {
-                                'name': 'name',
-                                'namespace': 'ns'
-                }
-              }
-        self.plugin.namespace = 'ns'
-        calico_kubernetes.DEFAULT_POLICY = 'ns_isolation'
-
-        # Call method under test empty annotations/namespace
-        return_val = self.plugin._generate_rules(pod)
-
-        inbound = [Rule(action="allow", src_tag="namespace_ns")]
-        outbound = [Rule(action="allow")]
-        expected = Rules(id=self.plugin.profile_name,
-                         inbound_rules=inbound,
-                         outbound_rules=outbound)
-
-        # Assert return value is correct.
-        assert_equal(return_val, expected)
-
     def test_generate_rules_ns_iso_override(self):
         """Test _generate_rules with ns_isolation and programmed policy
 
@@ -935,7 +927,7 @@ class NetworkPluginTest(unittest.TestCase):
             }
         }
         self.plugin.namespace = 'ns'
-        calico_kubernetes.DEFAULT_POLICY = 'ns_isolation'
+        self.plugin.default_policy = "ns_isolation"
 
         # Call method under test empty annotations/namespace
         return_val = self.plugin._generate_rules(pod)
@@ -950,9 +942,9 @@ class NetworkPluginTest(unittest.TestCase):
                          outbound_rules=[{'action': 'allow'}])
         assert_equal(return_val, expected)
 
-    @patch.object(calico_kubernetes, "DEFAULT_POLICY", "ns_isolation")
     def test_generate_rules_ns_isolation(self):
         pod = {'metadata': {'profile': 'name'}}
+        self.plugin.default_policy = "ns_isolation"
 
         # Expected result
         ns_tag = "namespace_%s" % self.plugin.namespace
@@ -1072,7 +1064,8 @@ class NetworkPluginTest(unittest.TestCase):
     @patch('calico_kubernetes.calico_kubernetes.run')
     @patch('calico_kubernetes.tests.kube_plugin_test.'
            'calico_kubernetes.configure_logger', autospec=True)
-    def test_run_protected(self, m_mode, m_conf_logger, m_run, m_sys_exit):
+    @patch('calico_kubernetes.calico_kubernetes.load_config', autospec=True)
+    def test_run_protected(self, m_mode, m_load_config, m_conf_logger, m_run, m_sys_exit):
         """Test global method run_protected
 
         Ensure code path not broken
@@ -1089,9 +1082,9 @@ class NetworkPluginTest(unittest.TestCase):
         assert_true(len(m_conf_logger.mock_calls) > 0)
         # Check we actually called the work function.
         if m_mode == 'init':
-            m_run.assert_called_with(mode=m_mode, namespace=None, pod_name=None, docker_id=None)
+            m_run.assert_called_with(mode=m_mode, namespace=None, pod_name=None, docker_id=None, config=m_load_config())
         else:
-            m_run.assert_called_with(mode=m_mode, namespace='ns_ns', pod_name='pod_pod', docker_id='id')
+            m_run.assert_called_with(mode=m_mode, namespace='ns_ns', pod_name='pod_pod', docker_id='id', config=m_load_config())
         # We should exit without error.
         m_sys_exit.assert_called_with(0)
 
@@ -1099,7 +1092,8 @@ class NetworkPluginTest(unittest.TestCase):
     @patch('calico_kubernetes.calico_kubernetes.run')
     @patch('calico_kubernetes.tests.kube_plugin_test.'
            'calico_kubernetes.configure_logger', autospec=True)
-    def test_run_protected_sys_exit(self, _, m_run, m_sys_exit):
+    @patch('calico_kubernetes.calico_kubernetes.load_config', autospec=True)
+    def test_run_protected_sys_exit(self, m_load_config, _, m_run, m_sys_exit):
         """Test failure in global method run_protected"""
         for exception_cls in (SystemExit, RuntimeError):
             _log.info('Testing that we handle %s exceptions',
@@ -1126,7 +1120,7 @@ class NetworkPluginTest(unittest.TestCase):
 
         Check for desired calls given a variety of inputs
         """
-        calico_kubernetes.run(m_mode, m_namespace, m_pod_name, m_docker_id)
+        calico_kubernetes.run(m_mode, m_namespace, m_pod_name, m_docker_id, CONFIG)
         if m_mode == 'status':
             m_plugin().status.assert_called_once_with(m_namespace, m_pod_name, m_docker_id)
         elif m_mode == 'setup':
@@ -1185,7 +1179,7 @@ class NetworkPluginTest(unittest.TestCase):
 
         Should return True
         """
-        calico_kubernetes.KUBE_API_ROOT = "https://test.com"
+        self.plugin.api_root = "https://test.com"
         return_val = self.plugin._api_root_secure()
         assert_true(return_val)
 
@@ -1194,7 +1188,7 @@ class NetworkPluginTest(unittest.TestCase):
 
         Should return False
         """
-        calico_kubernetes.KUBE_API_ROOT = "http://test.com"
+        self.plugin.api_root = "http://test.com"
         return_val = self.plugin._api_root_secure()
         assert_false(return_val)
 
@@ -1203,5 +1197,107 @@ class NetworkPluginTest(unittest.TestCase):
 
         Should raise SystemExit
         """
-        calico_kubernetes.KUBE_API_ROOT = "invalid"
+        self.plugin.api_root = "invalid"
         assert_raises(SystemExit, self.plugin._api_root_secure)
+
+    @patch("calico_kubernetes.calico_kubernetes.read_config_file", autospec=True)
+    @patch("calico_kubernetes.calico_kubernetes.os.environ", autospec=True)
+    def test_load_config_no_env(self, m_os_env, m_read_file):
+        """test_load_config when no env vars defined
+
+        When no environment varibles are defined, should use
+        the file configuration.
+        """
+        # Mock
+        file_resp = {
+            ETCD_AUTHORITY_VAR: "etcd-auth",
+            KUBE_AUTH_TOKEN_VAR: "kube-auth",
+            KUBE_API_ROOT_VAR: "kube-api",
+            DEFAULT_POLICY_VAR: "default-policy",
+            CALICO_IPAM_VAR: "calico-ipam",
+        }
+        # Deepcopy so that the original is not modified.
+        m_read_file.return_value = copy.deepcopy(file_resp)
+        m_os_env.get.return_value = None
+
+        # Call method
+        config = calico_kubernetes.load_config()
+
+        # The response should equal the file config.
+        expected = {
+        }
+        assert_equal(config, file_resp)
+
+    @patch("calico_kubernetes.calico_kubernetes.read_config_file", autospec=True)
+    @patch("calico_kubernetes.calico_kubernetes.os", autospec=True)
+    def test_load_config_env(self, m_os, m_read_file):
+        """test_load_config when env vars defined
+        """
+        # Mock
+        file_resp = {ETCD_AUTHORITY_VAR: ETCD_AUTHORITY_VAR}
+        m_read_file.return_value = file_resp 
+        m_os.environ.get.side_effect = lambda x: x
+
+        # Call method
+        config = calico_kubernetes.load_config()
+
+        # The response should equal the file config.
+        expected_resp = {
+            ETCD_AUTHORITY_VAR: ETCD_AUTHORITY_VAR,
+            KUBE_AUTH_TOKEN_VAR: KUBE_AUTH_TOKEN_VAR,
+            KUBE_API_ROOT_VAR: KUBE_API_ROOT_VAR,
+            DEFAULT_POLICY_VAR: DEFAULT_POLICY_VAR,
+            CALICO_IPAM_VAR: CALICO_IPAM_VAR,
+        }
+        assert_equal(config, expected_resp)
+
+    @patch("calico_kubernetes.calico_kubernetes.ConfigParser.ConfigParser", autospec=True)
+    @patch("calico_kubernetes.calico_kubernetes.os", autospec=True)
+    def test_read_config_file(self, m_os, m_parser):
+        """test_read_config_file
+
+        Tests reading from config file.
+        """
+        # Mock
+        m_parser().sections.return_value = ["config"]
+        m_parser().get.return_value = "default"
+        m_os.path.exists.return_value = True
+
+        # Call method under test
+        config = calico_kubernetes.read_config_file()
+
+        # Assert config equal
+        expected = {
+            ETCD_AUTHORITY_VAR: "default",
+            KUBE_AUTH_TOKEN_VAR: "default",
+            KUBE_API_ROOT_VAR: "default",
+            DEFAULT_POLICY_VAR: "default",
+            CALICO_IPAM_VAR: "default",
+            LOG_LEVEL_VAR: "DEFAULT", 
+        }
+        assert_equal(config, expected)
+
+    @patch("calico_kubernetes.calico_kubernetes.ConfigParser.ConfigParser", autospec=True)
+    @patch("calico_kubernetes.calico_kubernetes.os", autospec=True)
+    def test_read_config_file_invalid(self, m_os, m_parser):
+        """test_read_config_file_invalid no config section.
+
+        Invalid config file - no [section]
+        """
+        # Mock
+        m_parser().sections.return_value = []
+        m_os.path.exists.return_value = True
+
+        # Call method under test
+        assert_raises(SystemExit, calico_kubernetes.read_config_file)
+
+    @patch("calico_kubernetes.calico_kubernetes.ConfigParser.ConfigParser", autospec=True)
+    @patch("calico_kubernetes.calico_kubernetes.os", autospec=True)
+    def test_read_config_file_missing(self, m_os, m_parser):
+        """test_read_config_file_missing
+        """
+        # Mock
+        m_os.path.exists.return_value = False 
+
+        # Call method under test
+        assert_raises(SystemExit, calico_kubernetes.read_config_file)


### PR DESCRIPTION
Configuration can now be performed through an on-disk config file.

The file lives in the same directory as the plugin, and takes the name "calico_kubernetes.ini".

The file has the following format:
```
[config]
ETCD_AUTHORITY=some-etcd-auth:4001
CALICO_IPAM=true
KUBE_API_ROOT=http://api:8080/api/v1/
...
```
For back-compatibility / flexibility, environment variables of the same names can still be used.  Environment variables take precedence over config file variables.

Not in this PR: configuration via `etcd`.