### PR TITLE
Move logging filter to handlers

### DIFF
--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -834,16 +834,15 @@ def run_protected():
     if docker_id:
         configure_logger(logger=logger,
                          log_level=config[LOG_LEVEL_VAR],
+                         docker_id=str(docker_id)[:12],
                          log_format=DOCKER_ID_ROOT_LOG_FORMAT,
                          log_to_stdout=log_to_stdout)
         configure_logger(logger=pycalico_logger,
                          log_level=config[LOG_LEVEL_VAR],
+                         docker_id=str(docker_id)[:12],
                          log_format=DOCKER_ID_LOG_FORMAT,
                          log_to_stdout=log_to_stdout)
 
-        docker_filter = IdentityFilter(identity=str(docker_id)[:12])
-        logger.addFilter(docker_filter)
-        pycalico_logger.addFilter(docker_filter)
     else:
         configure_logger(logger=logger,
                          log_level=config[LOG_LEVEL_VAR],

--- a/calico_kubernetes/logutils.py
+++ b/calico_kubernetes/logutils.py
@@ -11,7 +11,7 @@ LOG_FORMAT = '%(asctime)s %(process)d %(levelname)s %(filename)s: %(message)s'
 DOCKER_ID_LOG_FORMAT = '%(asctime)s %(process)d [%(identity)s] %(levelname)s %(filename)s: %(message)s'
 
 
-def configure_logger(logger, log_level, log_format=LOG_FORMAT, 
+def configure_logger(logger, log_level, docker_id=None, log_format=LOG_FORMAT,
                      log_to_stdout=True, log_dir=LOG_DIR):
     """
     Configures logging to the file 'calico.log' in the specified log directory
@@ -33,11 +33,14 @@ def configure_logger(logger, log_level, log_format=LOG_FORMAT,
         os.makedirs(log_dir)
 
     formatter = logging.Formatter(log_format)
+    docker_filter = IdentityFilter(identity=docker_id)
 
     file_hdlr = ConcurrentRotatingFileHandler(filename=log_dir+'calico.log',
                                               maxBytes=1000000,
                                               backupCount=5)
     file_hdlr.setFormatter(formatter)
+    if docker_id:
+        file_hdlr.addFilter(docker_filter)
 
     logger.addHandler(file_hdlr)
     logger.setLevel(log_level)
@@ -47,6 +50,8 @@ def configure_logger(logger, log_level, log_format=LOG_FORMAT,
         stdout_hdlr = logging.StreamHandler(sys.stdout)
         stdout_hdlr.setLevel(log_level)
         stdout_hdlr.setFormatter(formatter)
+        if docker_id:
+            stdout_hdlr.addFilter(docker_filter)
         logger.addHandler(stdout_hdlr)
 
 class IdentityFilter(logging.Filter):

--- a/calico_kubernetes/tests/kube_plugin_test.py
+++ b/calico_kubernetes/tests/kube_plugin_test.py
@@ -1205,6 +1205,7 @@ class NetworkPluginTest(unittest.TestCase):
 
         logutils.configure_logger(logger=m_log,
                                   log_level=logging.DEBUG,
+                                  docker_id="abcd1234",
                                   log_format="FORMAT",
                                   log_to_stdout=m_log_to_stdout,
                                   log_dir='/mock/')


### PR DESCRIPTION
Filters, unlike levels and handlers, do not propogate to child loggers. Therefore, the child loggers of pycalico did not inherit the IdentityFilter. Fixed by attaching the filter to the handlers.